### PR TITLE
rearrange Core.ts and Bao.ts to allow use if the framework without im…

### DIFF
--- a/src/Bao.ts
+++ b/src/Bao.ts
@@ -3,12 +3,9 @@ import "./DataStore"
 import "./Focus"
 import "./Meta"
 
-export const $ = (id:string):any => document.getElementById($["prefix"]+id);
-$["prefix"] = "";
-
 export {default as Ajax} from "./Ajax";
 export {default as Carousel} from "./Carousel";
-export {default as Core} from "./Core";
+export {$, default as Core} from "./Core";
 export {default as DataStore} from "./DataStore";
 export {default as Focus} from "./Focus";
 export {default as Grid} from "./Grid";

--- a/src/Core.ts
+++ b/src/Core.ts
@@ -1,3 +1,6 @@
+export const $ = (id:string):any => document.getElementById($["prefix"]+id);
+$["prefix"] = "";
+
 let CoreImpl = {
 	Style: null,
 	Focus: null,
@@ -223,3 +226,8 @@ export default function Core(type?)
 }
 
 window.addEventListener("load", () => CoreImpl.setup());
+
+import "./Style"
+import "./DataStore"
+import "./Focus"
+import "./Meta"


### PR DESCRIPTION
…porting from 'baoframework' - results in smaller code.

This does not impact on the existing behaviour of: import ... from "baoframework";