### PR TITLE
Carousel: Enable option to skip translation

### DIFF
--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -149,11 +149,11 @@ class Carousel extends View
 		}
 	}
 
-	$goLeft()
+	$goLeft(skipTranslation?: boolean)
 	{
 		if (!this.wrap && this.index + 1 === this.numTiles) return;
 
-		if (this.translationComplete === true) {
+		if (this.translationComplete === true || skipTranslation) {
 			if (this.transform) this.translationComplete = false;
 			this.index++;
 			if (this.index % this.numTiles === 1) this.index = 1;

--- a/src/Carousel.ts
+++ b/src/Carousel.ts
@@ -206,11 +206,11 @@ class Carousel extends View
 		}
 	}
 
-	$goRight()
+	$goRight(skipTranslation?: boolean)
 	{
 		if (!this.wrap && this.index === 0) return;
 
-		if (this.translationComplete === true) {
+		if (this.translationComplete === true || skipTranslation) {
 			if (this.transform) this.translationComplete = false;
 			this.index--;
 			if (this.index < 0) this.index = this.numTiles - 1;


### PR DESCRIPTION
Enable option to skip translation (useful to go back to a specific tile in CarouselStack)