### PR TITLE
Fix $.parseDOM(root) from accessing ancestors

### DIFF
--- a/src/Core.ts
+++ b/src/Core.ts
@@ -178,7 +178,7 @@ $.parseDOM = (root?) => {
 	let node = root;
 	let deep = true;
 
-	do {
+	while (true) {
 		if (!node["stitched"]) {
 			if (node.attributes) {
 				let type = node.getAttribute("data-type");
@@ -209,11 +209,13 @@ $.parseDOM = (root?) => {
 		} else if (node.nextSibling) {
 			node = node.nextSibling;
 			deep = true;
+		} else if (node === root) {
+			break;
 		} else {
 			node = node.parentNode;
 			deep = false;
 		}
-	} while (node !== root);
+	}
 };
 
 // create


### PR DESCRIPTION
Without this change, the loop was accessing ancestors and eventually `XMLDocument` has no `parentNode`. This moves the exit condition inside the loop before trying to access ancestors.