### PR TITLE
Fix Regression: Components not creating sub-components correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baoframework",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "A lightweight framework from Thailand",
   "main": "./dist/Bao.js",
   "types": "./dist/Bao.d.ts",

--- a/src/View.ts
+++ b/src/View.ts
@@ -24,6 +24,7 @@ class View extends Base
 		if (this.element["stitched"]) throw new Error("DOM element already attached");
 		this.$_stitch();
 		this.$createContent();
+		$.parseDOM(this.element);
 		return (this.element as any);
 	}
 
@@ -35,6 +36,7 @@ class View extends Base
 		if (this.element["stitched"]) throw new Error("DOM element already attached");
 		this.$_stitch();
 		this.$createContent();
+		$.parseDOM(this.element);
 		return (this.element as any);
 	}
 
@@ -46,6 +48,7 @@ class View extends Base
 		if (this.element["stitched"]) throw new Error("DOM element already attached");
 		this.$_stitch();
 		this.$createContent();
+		$.parseDOM(this.element);
 		return (this.element as any);
 	}
 


### PR DESCRIPTION
This fixes a regression introduced in #52. `document.querySelector` returns a static `NodeListOf<Element>`, which meant that the creation of Views inside other Views was not working properly in some circumstances.